### PR TITLE
feat(skip token): Skip setting token when token is empty

### DIFF
--- a/root/etc/services.d/aria2/run
+++ b/root/etc/services.d/aria2/run
@@ -1,9 +1,13 @@
 #!/usr/bin/with-contenv bash
 
+if [[ ! -z $SECRET ]];then
+  SECRET_TOKEN="rpc-secret=${SECRET}"
+fi
+
 exec \
 	s6-setuidgid abc aria2c \
     --conf-path=/config/aria2.conf \
-    --rpc-secret=$SECRET \
+    $SECRET_TOKEN \
     --disk-cache=$CACHE \
     --quiet=$QUIET
   > /dev/stdout \


### PR DESCRIPTION
只有在使用者有設定$SECRET，才設定rpc-secret