### PR TITLE
rpc-secret command line argument missing prefix '--'

### DIFF
--- a/root/etc/services.d/aria2/run
+++ b/root/etc/services.d/aria2/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 if [[ ! -z $SECRET ]];then
-  SECRET_TOKEN="rpc-secret=${SECRET}"
+  SECRET_TOKEN="--rpc-secret=${SECRET}"
 fi
 
 exec \


### PR DESCRIPTION
在此次提交的pr中 #67 ，rpc-secret缺少前缀，导致缺少rpc认证。
现修正为--rpc-secret。